### PR TITLE
refactor: take parameter scaling out of main() (issue #2)

### DIFF
--- a/formset.py
+++ b/formset.py
@@ -538,7 +538,7 @@ class Setup(object):
         )
 
     def scale(self, total_memory, lowest_scale=0.0, human_readable=False):
-        # type: (int, float, bool) -> Tuple[Setup, float]
+        # type: (int, float, bool) -> Setup
         """
         Scale to the given memory usage.
 
@@ -567,7 +567,7 @@ class Setup(object):
 
         miny, minsp = f(lowest_scale)
         if miny >= 0:
-            return minsp, lowest_scale
+            return minsp
         # Optimize the memory usage by bisection.
         max_iteration = 50
         x1 = 1.0
@@ -612,7 +612,7 @@ class Setup(object):
                     raise AssertionError()
                 if not (y1 < y2):
                     raise AssertionError()
-        return f(x1)[1], x1
+        return f(x1)[1]
 
 
 def main():
@@ -830,16 +830,19 @@ def main():
         print("-m{0}x{1}".format(total_cpus // cpus, cpus))
         exit()
 
-    sp, x = sp.scale(memory, human_readable=args.human_readable)
+    sp = sp.scale(memory, human_readable=args.human_readable)
 
     # Final memory usage we've found.
     memory_usage = sp.calc()
 
-    if x < 1e-12:
+    if memory_usage > memory:
+        shortage = memory_usage - memory
         parser.exit(
             -1,
-            ("failed to find parameters: memory({0}) = {1} bytes shortage\n").format(
-                x, memory_usage - memory
+            ("failed to find parameters: {0} bytes shortage\n").format(
+                round_human_readable(shortage, True, True)
+                if args.human_readable
+                else str(shortage)
             ),
         )
 


### PR DESCRIPTION
Here's the proposed solution to issue #2. Compared to the diff I attached there, I've renamed `search` into `scale` and made it into a class member of `Setup`, which seemed a bit more appropriate (although I have no preferences either way). I've tried to make it so that the current CLI behavior is fully preserved, although my testing wasn't thorough.

The `lowest_scale` parameter is needed (by secdec) to define the fallback configuration. For the moment I plan to set it to `1.0`, so that parameters are only scaled up; `formset.py` CLI assumes it to be `0.0`, but that isn't a suitable fallback for secdec, because it would set `SmallSize`, `LargeSize`, etc, all to zero, and Form will likely fail with cryptic messages. In this case I'd prefer it to fail with "not enough memory", hence `1.0`.

The second return value of `scale` is needed by `main()` to detect insufficient memory and fail if so. Otherwise I don't care for this value that much, and would prefer it to be gone. I considered using a check like `sp.scale(2GB).calc() < 2GB` in `main()` instead, but at least in theory it can be unreliable, since bisection might produce configuration that uses 2GB+1B of memory. The probability of this is almost zero, but I wouldn't want to risk it anyway.

Note that I'm not at all attached to the API as it exists: if you'd like to rename `scale`, move it around, drop that second return value, etc -- this will be completely fine by me, and now is the best time to think about it.